### PR TITLE
Wrong user input (model can't be initialized) should return a 400 Error.

### DIFF
--- a/supercell/api/requesthandler.py
+++ b/supercell/api/requesthandler.py
@@ -133,6 +133,8 @@ class RequestHandler(rq):
                 except NoConsumerFound:
                     # TODO return available consumer types?!
                     raise HTTPError(406)
+                except ValueError:
+                    raise HTTPError(400)
 
             if verb in ['get', 'head']:
                 # check if there is caching information stored with the handler

--- a/test/test_requesthandler.py
+++ b/test/test_requesthandler.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, division, print_function, with_statement
 
 from schematics.models import Model
 from schematics.types import StringType
+from schematics.types import IntType
 
 from tornado.ioloop import IOLoop
 from tornado.testing import AsyncHTTPTestCase
@@ -31,6 +32,7 @@ from supercell.api.environment import Environment
 class SimpleMessage(Model):
     doc_id = StringType()
     message = StringType()
+    number = IntType()
 
 
 @provides(s.MediaType.ApplicationJson)
@@ -101,9 +103,15 @@ class TestSimpleRequestHandler(AsyncHTTPTestCase):
     def test_post_handler(self):
         response = self.fetch('/test_post', method='POST',
                               headers={'Content-Type': s.MediaType.ApplicationJson},
-                              body='{"message": "Simple message"}')
+                              body='{"message": "Simple message", "number": 1}')
         self.assertEqual(response.code, 201)
         self.assertEqual(response.body, '{"docid": 123, "ok": true}')
+
+    def test_post_handler_with_wrong_value_type(self):
+        response = self.fetch('/test_post', method='POST',
+                              headers={'Content-Type': s.MediaType.ApplicationJson},
+                              body='{"number": "one"}')
+        self.assertEqual(response.code, 400)
 
 
 @provides(s.MediaType.ApplicationJson, default=True)


### PR DESCRIPTION
Currently wrong user input that results in a non-caught ValueError exception returns a 500 Error, while it should be a 400 Error.

This is how the ValueError happens:

```
>>> from schematics.models import Model
>>> from schematics.types import IntType
>>> class Schema(Model):
...     number = IntType()
...
>>> Schema(**{"number": 1})
<Schema: Schema object>
>>> Schema(**{"number": "one"})
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "[...]/eggs/schematics-0.6-py2.7.egg/schematics/models.py", line 140, in __init__
    setattr(self, attr_name, field_value)
  File "[...]/eggs/schematics-0.6-py2.7.egg/schematics/types/base.py", line 423, in __set__
    value = self.number_class(value)
ValueError: invalid literal for int() with base 10: 'one'
```
