### PR TITLE
Adds possibility to raise 204 No Content HTTP Response Code

### DIFF
--- a/supercell/api/__init__.py
+++ b/supercell/api/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function, with_statement
 
 from supercell.api.metatypes import (ContentType, MediaType, Return, Ok,
-                                     Error, OkCreated)
+                                     Error, OkCreated, NoContent)
 from supercell.api.requesthandler import RequestHandler
 from supercell.api.decorators import provides, consumes, async
 from supercell.api.cache import CacheConfig
@@ -39,6 +39,7 @@ __all__ = [
     'Return',
     'Ok',
     'OkCreated',
+    'NoContent',
     'Error',
     'Service',
     'HealthCheckOk',

--- a/supercell/api/metatypes.py
+++ b/supercell/api/metatypes.py
@@ -67,6 +67,12 @@ class OkCreated(Ok):
         super(OkCreated, self).__init__(201, additional=additional)
 
 
+class NoContent(Return):
+
+    def __init__(self):
+        super(NoContent, self).__init__(ReturnInformation(204))
+
+
 class Error(Return):
 
     def __init__(self, code=400, additional=None):

--- a/supercell/api/requesthandler.py
+++ b/supercell/api/requesthandler.py
@@ -160,9 +160,10 @@ class RequestHandler(rq):
         if isinstance(result, ReturnInformationT):
             self.set_header('Content-Type', MediaType.ApplicationJson)
             self.set_status(result.code)
-            if 'additional' in result.message:
+            if result.message and 'additional' in result.message:
                 self.logger.info(result.message['additional'])
-            self.write(json.dumps(result.message))
+            if result.code != 204:
+                self.write(json.dumps(result.message))
 
         elif not isinstance(result, Model):
             # raise an error when something else than a model has been returned

--- a/test/test_requesthandler.py
+++ b/test/test_requesthandler.py
@@ -72,6 +72,10 @@ class MyEchoHandler(RequestHandler):
         # do something with model
         raise s.OkCreated({'docid': 123})
 
+    @s.async
+    def delete(self, *args, **kwargs):
+        raise s.NoContent()
+
 
 class TestSimpleRequestHandler(AsyncHTTPTestCase):
 
@@ -118,6 +122,10 @@ class TestSimpleRequestHandler(AsyncHTTPTestCase):
                               headers={'Content-Type': s.MediaType.ApplicationJson},
                               body='{"number": "one"}')
         self.assertEqual(response.code, 400)
+
+    def test_delete(self):
+        response = self.fetch('/test_post', method='DELETE')
+        self.assertEqual(response.code, 204)
 
 
 @provides(s.MediaType.ApplicationJson, default=True)


### PR DESCRIPTION
It would be nice to be able to return a 204 No Content, e.g. as response to a successful DELETE request.

By definition "The 204 response MUST NOT include a message-body", so we can't write in the requesthandler.
